### PR TITLE
openwebrtc-gst-plugins-static.recipe: Fix checking for openssl

### DIFF
--- a/recipes/openwebrtc-gst-plugins-static.recipe
+++ b/recipes/openwebrtc-gst-plugins-static.recipe
@@ -11,7 +11,8 @@ class Recipe(custom.GStreamerStatic):
     commit = 'origin/master'
     autoreconf = True
     autoreconf_sh = 'mkdir -p m4 && autoreconf -fiv'
-    patches = [_name + '/use-either-android-api-19-20.patch',]
+    patches = [_name + '/use-either-android-api-19-20.patch',
+               _name + '/optional-erdtls.patch',]
     deps = ['gettext', 'gstreamer-1.0', 'gst-plugins-base-1.0',
             'orc', 'libusrsctp']
     # Parallel make fails randomly due to .gitignore generation by git.mk
@@ -28,6 +29,7 @@ class Recipe(custom.GStreamerStatic):
     def prepare(self):
         # Don't build ercolorspace because we use videoconvert everywhere now
         self.configure_options += ' \
+            --disable-erdtls \
             --disable-debug \
             --disable-android-plugins \
             --disable-osx-plugins \


### PR DESCRIPTION
Complements 5eae63059643751862534a7a1053129245c001e2.

Interim solution for https://github.com/nirbheek/cerbero/issues/21
Upstream bug: https://github.com/EricssonResearch/openwebrtc-gst-plugins/pull/32